### PR TITLE
fix example config.json in manual section 2.6

### DIFF
--- a/doc/manual/manual.md
+++ b/doc/manual/manual.md
@@ -236,7 +236,7 @@ node accountManager.js
         "p2pport":      "30303",
         "wallet":"/mydata/nodedata-1/keys.info",
         "keystoredir":"/mydata/nodedata-1/keystore/",
-        "datadir":"/mydata/nodedata-1/",
+        "datadir":"/mydata/nodedata-1/data/",
         "vm":"interpreter",
         "networkid":"12345",
         "logverbosity":"4",


### PR DESCRIPTION
manual 2.6节中的示例config.json的datadir配置需要添加 data 目录，以和前面的bcoseth --gennetworkrlp 命令相匹配