### PR TITLE
修改sample/run.sh 一键运行脚本

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,8 @@ fi
 
 make -j2
 
-make install
+# sudo make install
+sudo cp eth/bcoseth /usr/local/bin/
 
 cd ..
 cd ./tool

--- a/sample/run.sh
+++ b/sample/run.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+
+if [ -d "/bcos-data" ]; then
+    sudo rm -rf /bcos-data
+fi
+
+if [ `whoami` = "root" ];then  
+    export PATH="${PATH}:/usr/local/bin"
+else
+    user=`whoami`
+    group=`groups`
+    sudo mkdir /bcos-data
+    sudo chown ${user}:${group} /bcos-data
+fi 
+
 node init.js node0.sample node1.sample
 chmod +x /bcos-data/node0/start0.sh
 chmod +x /bcos-data/node1/start1.sh

--- a/sample/start.sh.template
+++ b/sample/start.sh.template
@@ -1,3 +1,3 @@
 #!/bin/sh
-bcoseth   --genesis {genesis} --config {config}              
+nohup bcoseth --genesis {genesis} --config {config} >> out.log 2>&1  &     
 


### PR DESCRIPTION
1. run.sh  root 用户会遇到没有 /usrllocal/bin 路径的问题
2. 非root用户没有权限创建根目录
3. start模板错误
4. build.sh 中 make install 会安装一个共享动态链接库的执行文件，所以采用直接拷贝